### PR TITLE
fix(httphandler): log json.Encode and Write errors instead of ignoring

### DIFF
--- a/internal/adapter/httphandler/router.go
+++ b/internal/adapter/httphandler/router.go
@@ -1,6 +1,7 @@
 package httphandler
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -41,7 +42,9 @@ func NewRouter(todoSvc *apptodo.Service) http.Handler {
 	// Health check
 	r.Get("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte(`{"status":"ok"}`))
+		if _, err := w.Write([]byte(`{"status":"ok"}`)); err != nil {
+			slog.Warn("failed to write health response", "error", err)
+		}
 	})
 
 	return r

--- a/internal/adapter/httphandler/todo_handler.go
+++ b/internal/adapter/httphandler/todo_handler.go
@@ -2,6 +2,7 @@ package httphandler
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -41,7 +42,9 @@ func (h *TodoHandler) Create(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Location", "/todos/"+todo.ID)
 	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(toTodoResponse(todo))
+	if err := json.NewEncoder(w).Encode(toTodoResponse(todo)); err != nil {
+		slog.Warn("failed to encode response", "error", err, "path", r.URL.Path)
+	}
 }
 
 // Get handles GET /todos/{todoId} — retrieves a single Todo.
@@ -53,7 +56,9 @@ func (h *TodoHandler) Get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(toTodoResponse(todo))
+	if err := json.NewEncoder(w).Encode(toTodoResponse(todo)); err != nil {
+		slog.Warn("failed to encode response", "error", err, "path", r.URL.Path)
+	}
 }
 
 // List handles GET /todos — returns a paginated list of Todos.
@@ -86,7 +91,9 @@ func (h *TodoHandler) List(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(items)
+	if err := json.NewEncoder(w).Encode(items); err != nil {
+		slog.Warn("failed to encode response", "error", err, "path", r.URL.Path)
+	}
 }
 
 // Update handles PATCH /todos/{todoId} — partially updates a Todo.
@@ -109,7 +116,9 @@ func (h *TodoHandler) Update(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(toTodoResponse(todo))
+	if err := json.NewEncoder(w).Encode(toTodoResponse(todo)); err != nil {
+		slog.Warn("failed to encode response", "error", err, "path", r.URL.Path)
+	}
 }
 
 // Delete handles DELETE /todos/{todoId} — removes a Todo.
@@ -133,5 +142,7 @@ func (h *TodoHandler) Complete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(toTodoResponse(todo))
+	if err := json.NewEncoder(w).Encode(toTodoResponse(todo)); err != nil {
+		slog.Warn("failed to encode response", "error", err, "path", r.URL.Path)
+	}
 }

--- a/pkg/problemdetail/problem.go
+++ b/pkg/problemdetail/problem.go
@@ -3,6 +3,7 @@ package problemdetail
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 )
 
@@ -56,7 +57,9 @@ func (p *Problem) WithType(problemType string) *Problem {
 func (p *Problem) Write(w http.ResponseWriter) {
 	w.Header().Set("Content-Type", ContentType)
 	w.WriteHeader(p.Status)
-	_ = json.NewEncoder(w).Encode(p)
+	if err := json.NewEncoder(w).Encode(p); err != nil {
+		slog.Warn("failed to encode problem response", "error", err, "status", p.Status)
+	}
 }
 
 // NotFound returns a 404 Problem.


### PR DESCRIPTION
## Summary
- HTTP 응답 인코딩/쓰기 시 `_ =`로 무시하던 에러를 `slog.Warn`으로 로깅하도록 수정

## Motivation
운영 환경에서 클라이언트 연결 끊김 등으로 응답 인코딩이 실패할 때 조용히 무시되어 문제 추적이 불가능했음.

## Changes
- `pkg/problemdetail/problem.go` — `Write()` 메서드의 `Encode` 에러 로깅
- `internal/adapter/httphandler/todo_handler.go` — Create, Get, List, Update, Complete 5개 핸들러의 `Encode` 에러 로깅
- `internal/adapter/httphandler/router.go` — 헬스체크 `Write` 에러 로깅

## Test plan
- [x] `go test ./...` 통과
- [x] `go vet ./...` 통과

Closes #6

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.