### PR TITLE
fix(server): replace goroutine os.Exit with error channel and log Close errors

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,7 +32,11 @@ func main() {
 		slog.Error("failed to open database", "error", err)
 		os.Exit(1)
 	}
-	defer db.Close()
+	defer func() {
+		if err := db.Close(); err != nil {
+			slog.Error("failed to close database", "error", err)
+		}
+	}()
 
 	if err := pingDB(db); err != nil {
 		slog.Error("database ping failed", "error", err)
@@ -53,25 +57,31 @@ func main() {
 		IdleTimeout:  60 * time.Second,
 	}
 
-	// Start server in background
+	// Graceful shutdown on SIGINT or SIGTERM
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	// Start server in background, send errors via channel
+	errCh := make(chan error, 1)
 	go func() {
 		slog.Info("server starting", "addr", cfg.Server.Port)
 		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			slog.Error("server error", "error", err)
-			os.Exit(1)
+			errCh <- err
 		}
 	}()
 
-	// Graceful shutdown on SIGINT or SIGTERM
-	quit := make(chan os.Signal, 1)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	<-quit
+	// Wait for shutdown signal or server error
+	select {
+	case <-ctx.Done():
+		slog.Info("server shutting down")
+	case err := <-errCh:
+		slog.Error("server error", "error", err)
+	}
 
-	slog.Info("server shutting down")
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	if err := srv.Shutdown(ctx); err != nil {
+	if err := srv.Shutdown(shutdownCtx); err != nil {
 		slog.Error("forced shutdown", "error", err)
 	}
 	slog.Info("server stopped")

--- a/internal/adapter/postgresrepo/todo_repo.go
+++ b/internal/adapter/postgresrepo/todo_repo.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -64,7 +65,11 @@ func (r *TodoRepository) FindAll(ctx context.Context, cursor string, pageSize in
 	if err != nil {
 		return nil, "", fmt.Errorf("postgresrepo.TodoRepository.FindAll: %w", err)
 	}
-	defer rows.Close()
+	defer func() {
+		if err := rows.Close(); err != nil {
+			slog.Error("failed to close rows", "error", err)
+		}
+	}()
 
 	var todos []*domain.Todo
 	for rows.Next() {


### PR DESCRIPTION
## Summary
- goroutine 내 `os.Exit(1)`을 에러 채널 패턴으로 교체하여 defer 정리 루틴 실행 보장
- `db.Close()`, `rows.Close()` 에러를 `slog.Error`로 로깅

## Motivation
goroutine에서 `os.Exit` 호출 시 defer가 실행되지 않아 DB 연결이 정리되지 않음. `signal.NotifyContext` + 에러 채널 패턴으로 Go 관용적 graceful shutdown 구현.

## Changes
- `cmd/server/main.go` — `signal.NotifyContext` + `errCh` 패턴, `db.Close()` 에러 로깅
- `internal/adapter/postgresrepo/todo_repo.go` — `rows.Close()` 에러 로깅

## Test plan
- [x] `go test ./...` 통과
- [x] `go vet ./...` 통과

Closes #7

> 🤖 **AI Disclosure**: This implementation was assisted by **Claude Code**.